### PR TITLE
Update ghostscript to 9.25

### DIFF
--- a/net.scribus.Scribus.yml
+++ b/net.scribus.Scribus.yml
@@ -127,15 +127,15 @@ modules:
       - --with-drivers=FILES
     sources:
       - type:   archive
-        url:    https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs924/ghostscript-9.24.tar.xz
-        sha256: d44917df24979a05e0cb3916531928cc2adc91f5b17b419ee023d16ab31069d6
+        url:    https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-9.25.tar.xz
+        sha256: a2971a23bf15bbd9ddcd173141b15504e51ddc1d5a0a0144b00a6a8b14a62fed
       - type: shell
         commands:
           - rm -rf libpng/pngread.c
     cleanup:
       - /share/man
-      - /share/ghostscript/9.24/doc
-      - /share/ghostscript/9.24/examples
+      - /share/ghostscript/9.25/doc
+      - /share/ghostscript/9.25/examples
       # This is horrible, all we want to do is leave one file
       - dvipdf
       - font2c


### PR DESCRIPTION
This is another urgent security update of ghostscript, more info at https://www.ghostscript.com/doc/9.25/News.htm