### PR TITLE
Use the new openjpeg shared module

### DIFF
--- a/net.scribus.Scribus.yaml
+++ b/net.scribus.Scribus.yaml
@@ -29,7 +29,7 @@ finish-args:
   - --filesystem=host
 
 modules:
-  - shared-modules/python2.7/python-2.7.15.json
+  - shared-modules/python2.7/python-2.7.json
 
   - name: podofo
     buildsystem: cmake-ninja

--- a/net.scribus.Scribus.yaml
+++ b/net.scribus.Scribus.yaml
@@ -99,19 +99,7 @@ modules:
             sha256: 1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012
         cleanup:
           - /share/pkgconfig
-      - name: openjpeg2
-        buildsystem: cmake-ninja
-        config-opts:
-          - -DBUILD_CODEC=OFF
-        sources:
-          - type: archive
-            url: https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz
-            sha256: 3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a
-        cleanup:
-          - /include
-          - /lib/pkgconfig
-          - /lib/openjpeg-2.3
-          - '*.a'
+      - shared-modules/openjpeg/openjpeg.json
 
   - name: ghostscript
     config-opts:


### PR DESCRIPTION
In addition to the long term benefit of a shared maintenance, this also brings a couple of immediate wins: the latest release has bug and security fixes, and the cmake/cleanup config should result in a slightly faster and smaller build.

This required updating the submodule, and adapting the manifest for the Python 2 rename.