### PR TITLE
fix appdata patch file

### DIFF
--- a/net.scribus.Scribus.yaml
+++ b/net.scribus.Scribus.yaml
@@ -405,8 +405,8 @@ modules:
       - rm -rf /app/share/icons/hicolor/1024x1024
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/scribus/scribus/1.6.2/scribus-1.6.2.tar.xz
-        sha256: 7eff9b1f47e372e56bb369f1dbe18fe49101789b5e6bcfdb7890e0346b641383
+        url: https://downloads.sourceforge.net/project/scribus/scribus/1.6.3/scribus-1.6.3.tar.xz
+        sha256: 0ae58ced410101e82655e3b4c20a070cf1767145ada233dcef7c20b8ba6bd487
       - type: patch
         paths:
           - patches/scribus-appdata.patch

--- a/patches/scribus-appdata.patch
+++ b/patches/scribus-appdata.patch
@@ -2,36 +2,36 @@ diff --git a/scribus.appdata.xml.in b/scribus.appdata.xml.in
 index c38ef6b..e753dc9 100644
 --- a/scribus.appdata.xml.in
 +++ b/scribus.appdata.xml.in
-@@ -1,44 +1,72 @@
+@@ -1,44 +1,71 @@
  <?xml version="1.0" encoding="UTF-8"?>
--<!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2022> -->
+ <!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2022-2024> -->
 -<component>
 -  <id type="desktop">scribus@TAG_VERSION@.desktop</id>
 -  <metadata_license>CC0-1.0</metadata_license>
 -  <name>Scribus</name>
 -  <project_license>GPL-2.0+</project_license>
 -  <summary>Open Source Page Layout and Desktop Publishing (DTP)</summary>
--  <url type="homepage">http://www.scribus.net/</url>
+-  <url type="homepage">https://www.scribus.net/</url>
 -  <description>
--    <p>Scribus is a open source page layout program which
-+<!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2022-2024> -->
+-  <p>Scribus is a cross-platform open source page layout program which
+-produces commercial grade output in PDF and Postscript.</p>
+-  <p>While the goals of the program are ease of use and simple
+-easy-to-understand tools, Scribus support for professional
 +<component type="desktop-application">
 +	<id>scribus@TAG_VERSION@.desktop</id>
 +	<metadata_license>CC0-1.0</metadata_license>
 +	<name>Scribus</name>
 +	<project_license>GPL-2.0+</project_license>
 +	<summary>Open Source Page Layout and Desktop Publishing (DTP)</summary>
-+	<url type="homepage">http://www.scribus.net/</url>
++	<url type="homepage">https://www.scribus.net/</url>
 +	<url type="bugtracker">https://bugs.scribus.net/</url>
 +	<url type="vcs-browser">https://wiki.scribus.net/canvas/Checking_out_SVN</url>
 +	<description>
 +		<p>Scribus is a open source page layout program which
- produces commercial grade output in PDF and Postscript, primarily,
- though not exclusively, for Linux.</p>
--    <p>
-+		<p>
- While the goals of the program are ease of use and simple
- easy-to-understand tools, Scribus support for professional
++produces commercial grade output in PDF and Postscript, primarily,
++though not exclusively, for Linux.</p>
++		<p>While the goals of the program are ease of use and simple
++easy-to-understand tools, Scribus supports professional
  publishing features, such as CMYK and spot colors, easy PDF creation,
  Encapsulated Postscript import and export and creation of color
  separations.</p>
@@ -51,10 +51,12 @@ index c38ef6b..e753dc9 100644
 -    </screenshot>
 -  </screenshots>
 -  <update_contact>scribus-dev@lists.scribus.net</update_contact>
--  <content_rating type="oars-1.1"/>
+-  <content_rating type="oars-1.0"/>
 -  <releases>
+-    <release version="1.6.1" date="2024-01-07" type="stable"/>
+-    <release version="1.6.0" date="2024-01-01" type="stable"/>
 -    <release version="1.5.8" date="2022-01-23" type="development"/>
--	<release version="1.5.7" date="2021-04-25" type="development"/>
+-    <release version="1.5.7" date="2021-04-25" type="development"/>
 -    <release version="1.5.6.1" date="2020-11-14" type="development"/>
 -    <release version="1.5.6" date="2020-11-07" type="development"/>
 -	<release version="1.5.5" date="2019-07-30" type="development"/>
@@ -110,3 +112,4 @@ index c38ef6b..e753dc9 100644
 +		<release version="1.5.5" date="2019-07-30" type="development"/>
 +	</releases>
  </component>
+

--- a/patches/scribus-appdata.patch
+++ b/patches/scribus-appdata.patch
@@ -2,24 +2,111 @@ diff --git a/scribus.appdata.xml.in b/scribus.appdata.xml.in
 index c38ef6b..e753dc9 100644
 --- a/scribus.appdata.xml.in
 +++ b/scribus.appdata.xml.in
-@@ -1,7 +1,7 @@
+@@ -1,44 +1,72 @@
  <?xml version="1.0" encoding="UTF-8"?>
- <!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2022-2024> -->
+-<!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2022> -->
 -<component>
 -  <id type="desktop">scribus@TAG_VERSION@.desktop</id>
+-  <metadata_license>CC0-1.0</metadata_license>
+-  <name>Scribus</name>
+-  <project_license>GPL-2.0+</project_license>
+-  <summary>Open Source Page Layout and Desktop Publishing (DTP)</summary>
+-  <url type="homepage">http://www.scribus.net/</url>
+-  <description>
+-    <p>Scribus is a open source page layout program which
++<!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2022-2024> -->
 +<component type="desktop-application">
-+  <id>scribus@TAG_VERSION@.desktop</id>
-   <metadata_license>CC0-1.0</metadata_license>
-   <name>Scribus</name>
-   <project_license>GPL-2.0+</project_license>
-@@ -33,7 +33,10 @@ separations.</p>
-   <update_contact>scribus-dev@lists.scribus.net</update_contact>
-   <content_rating type="oars-1.0"/>
-+  <developer_name>Scribus developers</developer_name>
-+  <launchable type="desktop-id">net.scribus.Scribus.desktop</launchable>
-   <releases>
-+    <release version="1.6.2" date="2024-06-15" type="stable"/>
-     <release version="1.6.1" date="2024-01-07" type="stable"/>
-     <release version="1.6.0" date="2024-01-01" type="stable"/>
-     <release version="1.5.8" date="2022-01-23" type="development"/>
-     <release version="1.5.7" date="2021-04-25" type="development"/>
++	<id>scribus@TAG_VERSION@.desktop</id>
++	<metadata_license>CC0-1.0</metadata_license>
++	<name>Scribus</name>
++	<project_license>GPL-2.0+</project_license>
++	<summary>Open Source Page Layout and Desktop Publishing (DTP)</summary>
++	<url type="homepage">http://www.scribus.net/</url>
++	<url type="bugtracker">https://bugs.scribus.net/</url>
++	<url type="vcs-browser">https://wiki.scribus.net/canvas/Checking_out_SVN</url>
++	<description>
++		<p>Scribus is a open source page layout program which
+ produces commercial grade output in PDF and Postscript, primarily,
+ though not exclusively, for Linux.</p>
+-    <p>
++		<p>
+ While the goals of the program are ease of use and simple
+ easy-to-understand tools, Scribus support for professional
+ publishing features, such as CMYK and spot colors, easy PDF creation,
+ Encapsulated Postscript import and export and creation of color
+ separations.</p>
+-  </description>
+-  <screenshots>
+-    <screenshot type="default">
+-      <image height="708" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt2.png</image>
+-      <caption>Main Window with blank page</caption>
+-    </screenshot>
+-    <screenshot>
+-      <image height="702" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt18.png</image>
+-      <caption>Properties window</caption>
+-    </screenshot>
+-    <screenshot>
+-      <image height="477" width="629">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt16.png</image>
+-      <caption>Image effects tab</caption>
+-    </screenshot>
+-  </screenshots>
+-  <update_contact>scribus-dev@lists.scribus.net</update_contact>
+-  <content_rating type="oars-1.1"/>
+-  <releases>
+-    <release version="1.5.8" date="2022-01-23" type="development"/>
+-	<release version="1.5.7" date="2021-04-25" type="development"/>
+-    <release version="1.5.6.1" date="2020-11-14" type="development"/>
+-    <release version="1.5.6" date="2020-11-07" type="development"/>
+-	<release version="1.5.5" date="2019-07-30" type="development"/>
+-  </releases>
++	</description>
++	<screenshots>
++		<screenshot type="default">
++			<image height="708" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt2.png</image>
++			<caption>Main Window with blank page</caption>
++		</screenshot>
++		<screenshot>
++			<image height="702" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt18.png</image>
++			<caption>Properties window</caption>
++		</screenshot>
++		<screenshot>
++ 			<image height="477" width="629">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt16.png</image>
++			<caption>Image effects tab</caption>
++		</screenshot>
++	</screenshots>
++	<update_contact>scribus-dev@lists.scribus.net</update_contact>
++	<content_rating type="oars-1.1">
++		<content_attribute id="violence-cartoon">none</content_attribute>
++		<content_attribute id="violence-fantasy">none</content_attribute>
++		<content_attribute id="violence-realistic">none</content_attribute>
++		<content_attribute id="violence-bloodshed">none</content_attribute>
++		<content_attribute id="violence-sexual">none</content_attribute>
++		<content_attribute id="drugs-alcohol">none</content_attribute>
++		<content_attribute id="drugs-narcotics">none</content_attribute>
++		<content_attribute id="drugs-tobacco">none</content_attribute>
++		<content_attribute id="sex-nudity">none</content_attribute>
++		<content_attribute id="sex-themes">none</content_attribute>
++		<content_attribute id="language-profanity">none</content_attribute>
++		<content_attribute id="language-humor">none</content_attribute>
++		<content_attribute id="language-discrimination">none</content_attribute>
++		<content_attribute id="social-chat">none</content_attribute>
++		<content_attribute id="social-info">none</content_attribute>
++		<content_attribute id="social-audio">none</content_attribute>
++		<content_attribute id="social-location">none</content_attribute>
++		<content_attribute id="social-contacts">none</content_attribute>
++		<content_attribute id="money-purchasing">none</content_attribute>
++		<content_attribute id="money-gambling">none</content_attribute>
++	</content_rating>
++	<developer_name>Scribus developers</developer_name>
++	<launchable type="desktop-id">net.scribus.Scribus.desktop</launchable>
++	<releases>
++		<release version="1.6.2" date="2024-06-15" type="stable"/>
++		<release version="1.6.1" date="2024-01-07" type="stable"/>
++		<release version="1.6.0" date="2024-01-01" type="stable"/>
++		<release version="1.5.8" date="2022-01-23" type="development"/>
++		<release version="1.5.7" date="2021-04-25" type="development"/>
++		<release version="1.5.6.1" date="2020-11-14" type="development"/>
++		<release version="1.5.6" date="2020-11-07" type="development"/>
++		<release version="1.5.5" date="2019-07-30" type="development"/>
++	</releases>
+ </component>

--- a/patches/scribus-appdata.patch
+++ b/patches/scribus-appdata.patch
@@ -18,7 +18,7 @@ index c38ef6b..e753dc9 100644
    <description>
    <p>Scribus is a cross-platform open source page layout program which
  produces commercial grade output in PDF and Postscript.</p>
-@@ -31,7 +33,30 @@
+@@ -31,7 +33,9 @@
      </screenshot>
    </screenshots>
    <update_contact>scribus-dev@lists.scribus.net</update_contact>

--- a/patches/scribus-appdata.patch
+++ b/patches/scribus-appdata.patch
@@ -23,28 +23,7 @@ index c38ef6b..e753dc9 100644
    </screenshots>
    <update_contact>scribus-dev@lists.scribus.net</update_contact>
 -  <content_rating type="oars-1.0"/>
-+  <content_rating type="oars-1.1">
-+    <content_attribute id="violence-cartoon">none</content_attribute>
-+    <content_attribute id="violence-fantasy">none</content_attribute>
-+    <content_attribute id="violence-realistic">none</content_attribute>
-+    <content_attribute id="violence-bloodshed">none</content_attribute>
-+    <content_attribute id="violence-sexual">none</content_attribute>
-+    <content_attribute id="drugs-alcohol">none</content_attribute>
-+    <content_attribute id="drugs-narcotics">none</content_attribute>
-+    <content_attribute id="drugs-tobacco">none</content_attribute>
-+    <content_attribute id="sex-nudity">none</content_attribute>
-+    <content_attribute id="sex-themes">none</content_attribute>
-+    <content_attribute id="language-profanity">none</content_attribute>
-+    <content_attribute id="language-humor">none</content_attribute>
-+    <content_attribute id="language-discrimination">none</content_attribute>
-+    <content_attribute id="social-chat">none</content_attribute>
-+    <content_attribute id="social-info">none</content_attribute>
-+    <content_attribute id="social-audio">none</content_attribute>
-+    <content_attribute id="social-location">none</content_attribute>
-+    <content_attribute id="social-contacts">none</content_attribute>
-+    <content_attribute id="money-purchasing">none</content_attribute>
-+    <content_attribute id="money-gambling">none</content_attribute>
-+  </content_rating>
++  <content_rating type="oars-1.1" />
 +  <developer_name>Scribus developers</developer_name>
 +  <launchable type="desktop-id">net.scribus.Scribus.desktop</launchable>
    <releases>

--- a/patches/scribus-appdata.patch
+++ b/patches/scribus-appdata.patch
@@ -2,114 +2,51 @@ diff --git a/scribus.appdata.xml.in b/scribus.appdata.xml.in
 index c38ef6b..e753dc9 100644
 --- a/scribus.appdata.xml.in
 +++ b/scribus.appdata.xml.in
-@@ -1,44 +1,71 @@
+@@ -1,12 +1,14 @@
  <?xml version="1.0" encoding="UTF-8"?>
- <!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2022-2024> -->
+ <!-- Copyright 2016 Peter Linnell  plinnell@scribus.net, The Scribus Team 2002-2025> -->
 -<component>
--  <id type="desktop">scribus@TAG_VERSION@.desktop</id>
--  <metadata_license>CC0-1.0</metadata_license>
--  <name>Scribus</name>
--  <project_license>GPL-2.0+</project_license>
--  <summary>Open Source Page Layout and Desktop Publishing (DTP)</summary>
--  <url type="homepage">https://www.scribus.net/</url>
--  <description>
--  <p>Scribus is a cross-platform open source page layout program which
--produces commercial grade output in PDF and Postscript.</p>
--  <p>While the goals of the program are ease of use and simple
--easy-to-understand tools, Scribus support for professional
 +<component type="desktop-application">
-+	<id>scribus@TAG_VERSION@.desktop</id>
-+	<metadata_license>CC0-1.0</metadata_license>
-+	<name>Scribus</name>
-+	<project_license>GPL-2.0+</project_license>
-+	<summary>Open Source Page Layout and Desktop Publishing (DTP)</summary>
-+	<url type="homepage">https://www.scribus.net/</url>
-+	<url type="bugtracker">https://bugs.scribus.net/</url>
-+	<url type="vcs-browser">https://wiki.scribus.net/canvas/Checking_out_SVN</url>
-+	<description>
-+		<p>Scribus is a open source page layout program which
-+produces commercial grade output in PDF and Postscript, primarily,
-+though not exclusively, for Linux.</p>
-+		<p>While the goals of the program are ease of use and simple
-+easy-to-understand tools, Scribus supports professional
- publishing features, such as CMYK and spot colors, easy PDF creation,
- Encapsulated Postscript import and export and creation of color
- separations.</p>
--  </description>
--  <screenshots>
--    <screenshot type="default">
--      <image height="708" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt2.png</image>
--      <caption>Main Window with blank page</caption>
--    </screenshot>
--    <screenshot>
--      <image height="702" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt18.png</image>
--      <caption>Properties window</caption>
--    </screenshot>
--    <screenshot>
--      <image height="477" width="629">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt16.png</image>
--      <caption>Image effects tab</caption>
--    </screenshot>
--  </screenshots>
--  <update_contact>scribus-dev@lists.scribus.net</update_contact>
+   <id type="desktop">scribus@TAG_VERSION@.desktop</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <name>Scribus</name>
+   <project_license>GPL-2.0+</project_license>
+   <summary>Open Source Page Layout and Desktop Publishing (DTP)</summary>
+   <url type="homepage">https://www.scribus.net/</url>
++  <url type="bugtracker">https://bugs.scribus.net/</url>
++  <url type="vcs-browser">https://wiki.scribus.net/canvas/Checking_out_SVN</url>
+   <description>
+   <p>Scribus is a cross-platform open source page layout program which
+ produces commercial grade output in PDF and Postscript.</p>
+@@ -31,7 +33,30 @@
+     </screenshot>
+   </screenshots>
+   <update_contact>scribus-dev@lists.scribus.net</update_contact>
 -  <content_rating type="oars-1.0"/>
--  <releases>
--    <release version="1.6.1" date="2024-01-07" type="stable"/>
--    <release version="1.6.0" date="2024-01-01" type="stable"/>
--    <release version="1.5.8" date="2022-01-23" type="development"/>
--    <release version="1.5.7" date="2021-04-25" type="development"/>
--    <release version="1.5.6.1" date="2020-11-14" type="development"/>
--    <release version="1.5.6" date="2020-11-07" type="development"/>
--	<release version="1.5.5" date="2019-07-30" type="development"/>
--  </releases>
-+	</description>
-+	<screenshots>
-+		<screenshot type="default">
-+			<image height="708" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt2.png</image>
-+			<caption>Main Window with blank page</caption>
-+		</screenshot>
-+		<screenshot>
-+			<image height="702" width="1000">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt18.png</image>
-+			<caption>Properties window</caption>
-+		</screenshot>
-+		<screenshot>
-+ 			<image height="477" width="629">https://raw.githubusercontent.com/scribusproject/scribus/master/doc/en/images/Rembrandt16.png</image>
-+			<caption>Image effects tab</caption>
-+		</screenshot>
-+	</screenshots>
-+	<update_contact>scribus-dev@lists.scribus.net</update_contact>
-+	<content_rating type="oars-1.1">
-+		<content_attribute id="violence-cartoon">none</content_attribute>
-+		<content_attribute id="violence-fantasy">none</content_attribute>
-+		<content_attribute id="violence-realistic">none</content_attribute>
-+		<content_attribute id="violence-bloodshed">none</content_attribute>
-+		<content_attribute id="violence-sexual">none</content_attribute>
-+		<content_attribute id="drugs-alcohol">none</content_attribute>
-+		<content_attribute id="drugs-narcotics">none</content_attribute>
-+		<content_attribute id="drugs-tobacco">none</content_attribute>
-+		<content_attribute id="sex-nudity">none</content_attribute>
-+		<content_attribute id="sex-themes">none</content_attribute>
-+		<content_attribute id="language-profanity">none</content_attribute>
-+		<content_attribute id="language-humor">none</content_attribute>
-+		<content_attribute id="language-discrimination">none</content_attribute>
-+		<content_attribute id="social-chat">none</content_attribute>
-+		<content_attribute id="social-info">none</content_attribute>
-+		<content_attribute id="social-audio">none</content_attribute>
-+		<content_attribute id="social-location">none</content_attribute>
-+		<content_attribute id="social-contacts">none</content_attribute>
-+		<content_attribute id="money-purchasing">none</content_attribute>
-+		<content_attribute id="money-gambling">none</content_attribute>
-+	</content_rating>
-+	<developer_name>Scribus developers</developer_name>
-+	<launchable type="desktop-id">net.scribus.Scribus.desktop</launchable>
-+	<releases>
-+		<release version="1.6.2" date="2024-06-15" type="stable"/>
-+		<release version="1.6.1" date="2024-01-07" type="stable"/>
-+		<release version="1.6.0" date="2024-01-01" type="stable"/>
-+		<release version="1.5.8" date="2022-01-23" type="development"/>
-+		<release version="1.5.7" date="2021-04-25" type="development"/>
-+		<release version="1.5.6.1" date="2020-11-14" type="development"/>
-+		<release version="1.5.6" date="2020-11-07" type="development"/>
-+		<release version="1.5.5" date="2019-07-30" type="development"/>
-+	</releases>
- </component>
-
++  <content_rating type="oars-1.1">
++    <content_attribute id="violence-cartoon">none</content_attribute>
++    <content_attribute id="violence-fantasy">none</content_attribute>
++    <content_attribute id="violence-realistic">none</content_attribute>
++    <content_attribute id="violence-bloodshed">none</content_attribute>
++    <content_attribute id="violence-sexual">none</content_attribute>
++    <content_attribute id="drugs-alcohol">none</content_attribute>
++    <content_attribute id="drugs-narcotics">none</content_attribute>
++    <content_attribute id="drugs-tobacco">none</content_attribute>
++    <content_attribute id="sex-nudity">none</content_attribute>
++    <content_attribute id="sex-themes">none</content_attribute>
++    <content_attribute id="language-profanity">none</content_attribute>
++    <content_attribute id="language-humor">none</content_attribute>
++    <content_attribute id="language-discrimination">none</content_attribute>
++    <content_attribute id="social-chat">none</content_attribute>
++    <content_attribute id="social-info">none</content_attribute>
++    <content_attribute id="social-audio">none</content_attribute>
++    <content_attribute id="social-location">none</content_attribute>
++    <content_attribute id="social-contacts">none</content_attribute>
++    <content_attribute id="money-purchasing">none</content_attribute>
++    <content_attribute id="money-gambling">none</content_attribute>
++  </content_rating>
++  <developer_name>Scribus developers</developer_name>
++  <launchable type="desktop-id">net.scribus.Scribus.desktop</launchable>
+   <releases>
+     <release version="1.6.3" date="2025-01-08" type="stable"/>
+     <release version="1.6.2" date="2024-06-15" type="stable"/>


### PR DESCRIPTION
This patch includes more information in the appdata file.

With the next Scribus release version, the whole scribus-appdata.patch file will be obsolete.